### PR TITLE
fix: re-export types used by pub api

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,4 +1,5 @@
-use memory_addr::{AddrRange, PhysAddr, VirtAddr, def_usize_addr, def_usize_addr_formatter};
+pub use memory_addr::{AddrRange, PhysAddr, VirtAddr};
+use memory_addr::{def_usize_addr, def_usize_addr_formatter};
 
 /// Host virtual address.
 pub type HostVirtAddr = VirtAddr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ pub use address_space::*;
 pub use frame::PhysFrame;
 pub use hal::AxMmHal;
 
-use axerrno::AxError;
-use memory_set::MappingError;
+pub use axerrno::AxError;
+pub use memory_set::MappingError;
 
 /// Information about nested page faults.
 #[derive(Debug)]


### PR DESCRIPTION
Re-export the dependency types used by the API, so that users don't have to manage the versions of transitive dependencies, and multiple versions can coexist.